### PR TITLE
Enable CPU-only automatic inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,22 @@ python sam_test.py --data_dir data --pretrained_model *path_to_model/model.pt --
 
 ## Inference
 To run inference, we need to provide bbox coordinates for the segmentation region in the image (automated). This is how SAM works,i.e. it requires a prompt along with image for prediction. In our case, the prompt is the bbox coordinates. We provide a script to run inference on a single image. To run inference, run the following command:
-```     
+```
 python sam_infer.py --image_path {PATH_TO_IMAGE_OR_DIR} --pretrained_model weights/model.pt --save_dir results
 ```
 
-when  you run the above command, an image window will be opened. You will be asked to draw (click) the top left and bottom right coordinates of the bbox using mouse pointer.  Results will be saved in `save_dir` (default: `outputs/results`). The results include the overlay of predicted and ground truth masks. 
+when you run the above command, an image window will be opened. You will be asked to draw (click) the top left and bottom right coordinates of the bbox using mouse pointer. Results will be saved in `save_dir` (default: `outputs/results`). The results include the overlay of predicted and ground truth masks.
+
+For systems without a GPU (e.g., a CPU-only Mac) you can force CPU inference and skip the manual bounding box by using the `--device` and `--auto_bbox` flags:
+
+```
+python sam_infer.py --image_path {PATH_TO_IMAGE_OR_DIR} --pretrained_model weights/model.pt --save_dir results --device cpu --auto_bbox
+```
 
 The inference command can either take a single image or a directory containing multiple images as input. In case of directory, also provide the extension of the images. For example, if the images are in `.jpg` format, run the following command:
 
 ```
-python sam_infer.py --image_path {PATH_TO_IMAGE_DIR} -extension jpg --pretrained_model weights/model.pt --save_dir results
+python sam_infer.py --image_path {PATH_TO_IMAGE_DIR} -extension jpg --pretrained_model weights/model.pt --save_dir results --device cpu --auto_bbox
 ```
 ## Results
 <p align="center" style="display: flex; justify-content: center; align-items: center;">

--- a/sam_infer.py
+++ b/sam_infer.py
@@ -1,6 +1,6 @@
 # casia-interval-v3 dataset
 import os
-from segment_anything import  sam_model_registry, SamPredictor
+from segment_anything import sam_model_registry, SamPredictor
 import torch
 import numpy as np
 import cv2
@@ -42,7 +42,7 @@ def draw_box_points(image, name='Image', num_points=4):
     return params['points']
     
 
-def infer(image_path, save_dir, pretrained_model, extension='jpg'):
+def infer(image_path, save_dir, pretrained_model, extension='jpg', device="auto", auto_bbox=False):
     
 
     if os.path.isdir(image_path):
@@ -54,7 +54,14 @@ def infer(image_path, save_dir, pretrained_model, extension='jpg'):
         print('image_path is not a valid file or directory')
         exit()
         
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "auto":
+        if torch.cuda.is_available():
+            device = "cuda"
+        elif getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+            device = "mps"
+        else:
+            device = "cpu"
+
     model_type = 'vit_h'
     checkpoint = pretrained_model
     
@@ -74,10 +81,13 @@ def infer(image_path, save_dir, pretrained_model, extension='jpg'):
         
         input_image = cv2.imread(image_file)
         
-        # use cv2 to get 4 points as a bounding boux from user}
-        bbox = draw_box_points(input_image, name=image_name)
-        # bbox = [(0,0), (input_image.shape[1], input_image.shape[0])]
-        print('BBox coordinates provided by user: ', bbox)
+        if auto_bbox:
+            bbox = [(0, 0), (input_image.shape[1], input_image.shape[0])]
+            print('Using full image as bounding box')
+        else:
+            # use cv2 to get 4 points as a bounding box from user
+            bbox = draw_box_points(input_image, name=image_name)
+            print('BBox coordinates provided by user: ', bbox)
         
         input_image = input_image[:,:,::-1] # convert to RGB
         predictor.set_image(input_image)
@@ -101,16 +111,18 @@ def infer(image_path, save_dir, pretrained_model, extension='jpg'):
 
 
 if __name__ == '__main__':
-    
+
     import argparse
     parser = argparse.ArgumentParser('SAM model inference')
     parser.add_argument('--image_path', type=str, required=True, help='path to an image file or directory of images')
     parser.add_argument('--extension', type=str, default='jpg', help='image file extension, useful if image_path is a directory')
     parser.add_argument('--save_dir', type=str, default='results', help='path to save directory')
     parser.add_argument('--pretrained_model', type=str, default='weights/model.pt', help='path to pretrained model')
+    parser.add_argument('--device', type=str, default='auto', help='device to run on: auto, cpu, cuda, or mps')
+    parser.add_argument('--auto_bbox', action='store_true', help='use the full image as bounding box instead of manual selection')
     # parser.add_argument('--batch_size', type=int, default=2, help='batch size') # does not work with batch size > 1
-    
+
     args = parser.parse_args()
-    
-    infer(args.image_path, args.save_dir, args.pretrained_model, args.extension)
+
+    infer(args.image_path, args.save_dir, args.pretrained_model, args.extension, device=args.device, auto_bbox=args.auto_bbox)
     


### PR DESCRIPTION
## Summary
- allow selecting device (CPU, CUDA, or MPS) and automatic full-image bounding boxes in `sam_infer.py`
- document CPU-only usage with `--device` and `--auto_bbox` flags in README

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ec2a1dac832a8444fe2d5b30e560